### PR TITLE
Fix cluster mode

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ resource "aws_elasticache_replication_group" "default" {
   replication_group_id          = var.replication_group_id == "" ? module.label.id : var.replication_group_id
   replication_group_description = module.label.id
   node_type                     = var.instance_type
-  number_cache_clusters         = var.cluster_mode_enabled ? (1 + var.cluster_mode_replicas_per_node_group) * var.cluster_mode_num_node_groups : var.cluster_size
+  number_cache_clusters         = var.cluster_mode_enabled ? null : var.cluster_size
   port                          = var.port
   parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
   availability_zones            = slice(var.availability_zones, 0, var.cluster_size)

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_elasticache_replication_group" "default" {
   number_cache_clusters         = var.cluster_mode_enabled ? null : var.cluster_size
   port                          = var.port
   parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
-  availability_zones            = slice(var.availability_zones, 0, var.cluster_size)
+  availability_zones            = var.cluster_mode_enabled ? null : slice(var.availability_zones, 0, var.cluster_size)
   automatic_failover_enabled    = var.automatic_failover_enabled
   subnet_group_name             = local.elasticache_subnet_group_name
   security_group_ids            = var.use_existing_security_groups ? var.existing_security_groups : [join("", aws_security_group.default.*.id)]


### PR DESCRIPTION
## what
* fix creation on `cluster_mode_enabled`
* don't send `number_cache_clusters` or `availability_zones` for cluster mode

## why
* neither parameter are supported for cluster mode; more info:
  * [`number_cache_clusters`](https://github.com/terraform-providers/terraform-provider-aws/issues/10458#issuecomment-549522250)
  * [`availability_zones`](https://github.com/terraform-providers/terraform-provider-aws/issues/5104#issuecomment-403123630)

## references
* duplicates: https://github.com/cloudposse/terraform-aws-elasticache-redis/pull/65